### PR TITLE
Add versioning_scheme() method in Role::Versioning::Scheme.

### DIFF
--- a/lib/Role/Versioning/Scheme.pm
+++ b/lib/Role/Versioning/Scheme.pm
@@ -13,8 +13,25 @@ requires qw(
                parse_version
        );
 
+sub versioning_scheme {
+    my $class = shift;
+    $class = ref $class if ref $class;
+    $class =~ s/\AVersioning::Scheme:://;
+    $class;
+}
+
 1;
 # ABSTRACT: Role for Versioning::Scheme::* modules
+
+=head1 PROVIDED METHODS
+
+=head2 versioning_scheme
+
+Usage:
+
+ print $vs->versioning_scheme; # Dotted
+
+Print the versioning scheme name.
 
 =head1 REQUIRED METHODS
 

--- a/lib/Versioning/Scheme/Dotted.pm
+++ b/lib/Versioning/Scheme/Dotted.pm
@@ -151,6 +151,8 @@ L<Role::Versioning::Scheme>.
 
 =head1 METHODS
 
+=head2 versioning_scheme
+
 =head2 is_valid_version
 
 =head2 parse_version

--- a/lib/Versioning/Scheme/Monotonic.pm
+++ b/lib/Versioning/Scheme/Monotonic.pm
@@ -156,6 +156,8 @@ increase COMPATIBILITY instead; but in that case RELEASE will still be bumped by
 
 =head1 METHODS
 
+=head2 versioning_scheme
+
 =head2 is_valid_version
 
 =head2 parse_version

--- a/lib/Versioning/Scheme/Perl.pm
+++ b/lib/Versioning/Scheme/Perl.pm
@@ -144,6 +144,8 @@ L<version>.pm.
 
 =head1 METHODS
 
+=head2 versioning_scheme
+
 =head2 is_valid_version
 
 Uses L<version>.pm's C<parse()>.

--- a/lib/Versioning/Scheme/Semantic.pm
+++ b/lib/Versioning/Scheme/Semantic.pm
@@ -150,6 +150,8 @@ L<Role::Versioning::Scheme>.
 
 =head1 METHODS
 
+=head2 versioning_scheme
+
 =head2 is_valid_version
 
 =head2 parse_version


### PR DESCRIPTION
This will make it easy for consumer class users to know which versioning scheme
the class follows.